### PR TITLE
fix: Change DAG schedule to run on weekdays at 1 PM

### DIFF
--- a/airflow/dags/pipeline_fsc_fund.py
+++ b/airflow/dags/pipeline_fsc_fund.py
@@ -7,7 +7,8 @@ from etl_utils import fetch_fsc_funds, transform_fsc_funds, load_to_mongo, get_m
 @dag(
     dag_id="fsc_fund_standard_code_pipeline",
     start_date=pendulum.datetime(2025, 11, 1, tz="Asia/Seoul"),
-    schedule="20 3 * * *", 
+    #금융위원회 펀드 정보 api 갱신 시간 매 영업일 다음날 오후 한시임
+    schedule="5 13 * * 1-5", 
     catchup=False,
     tags=["fsc", "fund", "etl", "team_4", "preprocessing"],
 )


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>

어떤 변경사항이 있었나요?

* [ ] 🐞 BugFix Something isn't working
* [ ] 🎨 Design Markup & styling
* [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
* [ ] ✨ Feature Feature
* [x] 🔨 Refactor Code refactoring
* [x] ⚙️ Setting Development environment setup
* [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

* [x] PR 컨벤션에 맞게 작성했습니다. (필수)
* [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
* [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
* [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

* **DAG 실행 스케줄 변경**: 기존 스케줄을 삭제하고, 평일(월-금) 오후 1시에 주기적으로 실행되도록 수정함.
* **Cron 표현식 적용**: `schedule_interval='0 13 * * 1-5'` (또는 Airflow 2.4+ 버전의 경우 `schedule='0 13 * * 1-5'`) 적용.
* `0`: 0분
* `13`: 13시 (오후 1시)
* `* *`: 매일, 매월
* `1-5`: 월요일(1)부터 금요일(5)까지



## Uncompleted Tasks 😅

* [ ] N/A

## To Reviewers 📢

* UTC 시간 설정인지, KST(한국 시간) 설정인지에 따라 실제 실행 시간이 달라질 수 있습니다. 현재 DAG 서버 타임존 설정이 **KST 기준**임을 확인하고 `13시`로 설정했습니다. 만약 서버가 **UTC 기준**이라면 `0 4 * * 1-5` (UTC 04:00 = KST 13:00)로 수정이 필요하니 검토 부탁드립니다.